### PR TITLE
Update URL of policies.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+SHELL=/bin/bash
+
 .PHONY: update
 
 all-actions.txt: var/app.json bin/all-actions
@@ -22,7 +24,7 @@ var/app.json: var/policies.js
 
 var/policies.js:
 	mkdir -p var
-	curl -o $@.tmp https://awsiamconsole.s3.amazonaws.com/iam/assets/js/bundles/policies.js && mv $@.tmp $@
+	curl -o $@.tmp https://awspolicygen.s3.amazonaws.com/js/policies.js && mv $@.tmp $@
 
 update:
 	rm -f var/policies.js


### PR DESCRIPTION
Thanks for maintaining this!
I noticed that the automatically updated all-actions.txt didn't change since 2018.

Changes:
- use up-to-date URL of policies.js
- also explicitly make make use bash (it uses sh on my Ubuntu 18, and `make update` fails because `-o pipefail` is not available)

URL taken from the policygen page: 
![image](https://user-images.githubusercontent.com/3134153/67050225-5a7b3f80-f138-11e9-8594-a5cb77fbbd73.png)

Should I also add the all-actions.txt or will it be automatically generated after this PR is merged?

Thanks!
